### PR TITLE
Split MPU functionality to run alongside PicoGUS

### DIFF
--- a/pgusinit/pgusinit.c
+++ b/pgusinit/pgusinit.c
@@ -287,13 +287,33 @@ int main(int argc, char* argv[]) {
 
     int i = 1;
     while (i < argc) {
+        if (stricmp(argv[i], "/m") == 0) {
+            CONTROL_PORT=0x1D3; // Change the GUS ports to MPU mode
+            DATA_PORT_LOW=0x1D4;
+            DATA_PORT_HIGH=0x1D5;
+        }
+        ++i;
+    }
+    i = 1;
+    
+    banner();
+    // Get magic value from port on PicoGUS that is not on real GUS
+    outp(CONTROL_PORT, 0xCC); // Knock on the door...
+    outp(CONTROL_PORT, 0x00); // Select magic string register
+    if (inp(DATA_PORT_HIGH) != 0xDD) {
+        err_pigus(); // Nobody is home
+        return 99;
+    };
+    printf("PicoGUS detected: ");
+    print_firmware_string();
+
+    outp(CONTROL_PORT, 0x03); // Select mode register
+    mode = inp(DATA_PORT_HIGH);
+
+    while (i < argc) {
         if (stricmp(argv[i], "/?") == 0) {
             usage(argv[0], mode);
             return 0;
-        } else if (stricmp(argv[i], "/m") == 0) {
-            CONTROL_PORT=0x1D3; // Change the GUS ports to MPU
-            DATA_PORT_LOW=0x1D4;
-            DATA_PORT_HIGH=0x1D5;
         } else if (stricmp(argv[i], "/j") == 0) {
             enable_joystick = 1;
         } else if (stricmp(argv[i], "/a") == 0) {
@@ -353,20 +373,6 @@ int main(int argc, char* argv[]) {
         }
         ++i;
     }
-
-    banner();
-    // Get magic value from port on PicoGUS that is not on real GUS
-    outp(CONTROL_PORT, 0xCC); // Knock on the door...
-    outp(CONTROL_PORT, 0x00); // Select magic string register
-    if (inp(DATA_PORT_HIGH) != 0xDD) {
-        err_pigus(); // Nobody is home
-        return 99;
-    };
-    printf("PicoGUS detected: ");
-    print_firmware_string();
-
-    outp(CONTROL_PORT, 0x03); // Select mode register
-    mode = inp(DATA_PORT_HIGH);
 
     outp(CONTROL_PORT, 0x01); // Select protocol version register
     uint8_t protocol_got = inp(DATA_PORT_HIGH);

--- a/pgusinit/pgusinit.c
+++ b/pgusinit/pgusinit.c
@@ -301,7 +301,7 @@ int main(int argc, char* argv[]) {
     outp(CONTROL_PORT, 0xCC); // Knock on the door...
     outp(CONTROL_PORT, 0x00); // Select magic string register
     if (inp(DATA_PORT_HIGH) != 0xDD) {
-        err_pigus(); // Nobody is home
+        err_pigus();
         return 99;
     };
     printf("PicoGUS detected: ");

--- a/pgusinit/pgusinit.c
+++ b/pgusinit/pgusinit.c
@@ -7,10 +7,11 @@
 #include <stdbool.h>
 #include <i86.h>
 
-#define CONTROL_PORT 0x1D0
-#define DATA_PORT_LOW  0x1D1
-#define DATA_PORT_HIGH 0x1D2
 #define PICOGUS_PROTOCOL_VER 2
+
+unsigned short CONTROL_PORT=0x1D0; // Change to a variable with GUS defaults
+unsigned short DATA_PORT_LOW=0x1D1;
+unsigned short DATA_PORT_HIGH=0x1D2;
 
 typedef enum {
     PICO_FIRMWARE_IDLE = 0,
@@ -288,8 +289,16 @@ int main(int argc, char* argv[]) {
     outp(CONTROL_PORT, 0xCC); // Knock on the door...
     outp(CONTROL_PORT, 0x00); // Select magic string register
     if (inp(DATA_PORT_HIGH) != 0xDD) {
-        err_pigus();
-        return 99;
+        CONTROL_PORT=0x1D3; // Let's see if there's a MPU
+        DATA_PORT_LOW=0x1D4;
+        DATA_PORT_HIGH=0x1D5;
+        // Get magic value from port on PicoGUS that is running MPU firmware
+        outp(CONTROL_PORT, 0xCC); // Knock on the door...
+        outp(CONTROL_PORT, 0x00); // Select magic string register
+        if (inp(DATA_PORT_HIGH) != 0xDD) {
+            err_pigus(); // Nobody is home
+            return 99;
+        }
     };
     printf("PicoGUS detected: ");
     print_firmware_string();

--- a/pgusinit/pgusinit.c
+++ b/pgusinit/pgusinit.c
@@ -294,7 +294,6 @@ int main(int argc, char* argv[]) {
             CONTROL_PORT=0x1D3; // Change the GUS ports to MPU
             DATA_PORT_LOW=0x1D4;
             DATA_PORT_HIGH=0x1D5;
-        }
         } else if (stricmp(argv[i], "/j") == 0) {
             enable_joystick = 1;
         } else if (stricmp(argv[i], "/a") == 0) {

--- a/pgusinit/pgusinit.c
+++ b/pgusinit/pgusinit.c
@@ -57,7 +57,7 @@ void usage(char *argv0, card_mode_t mode) {
     fprintf(stderr, "    /?        - show this message\n");
     fprintf(stderr, "    /f fw.uf2 - program the PicoGUS with the firmware file fw.uf2\n");
     fprintf(stderr, "    /j        - enable USB joystick support\n");
-    fprintf(stderr, "    /m        - enable MPU-401 communication\n");
+    fprintf(stderr, "    /m        - switch to PicoMPU communication\n");
     if (mode > GUS_MODE && mode < JOYSTICK_ONLY_MODE) {
         fprintf(stderr, "AdLib, MPU-401, Tandy, CMS modes only:\n");
         fprintf(stderr, "    /p x - set the (hex) base port address of the emulated card. Defaults:\n");

--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -132,7 +132,7 @@ if(PROJECT_TYPE STREQUAL "OPL")
 endif()
 
 if(PROJECT_TYPE STREQUAL "MPU")
-    pico_set_program_name(picogus "picogus-mpu401")
+    pico_set_program_name(picogus "picompu-mpu401")
     target_compile_definitions(picogus PRIVATE
         SOUND_MPU=1
     )

--- a/sw/picogus.cpp
+++ b/sw/picogus.cpp
@@ -98,10 +98,19 @@ uint8_t joystate_bin;
 
 // PicoGUS control and data ports
 // 1D0 chosen as the base port as nothing is listed in Ralf Brown's Port List (http://www.cs.cmu.edu/~ralf/files.html)
+// MPU moved to 1D3-1D5 to function alongside PicoGUS
+#ifdef SOUND_MPU
+#define CONTROL_PORT 0x1D3
+#define DATA_PORT_LOW  0x1D4
+#define DATA_PORT_HIGH 0x1D5
+#define PICOGUS_PROTOCOL_VER 2
+#else
 #define CONTROL_PORT 0x1D0
 #define DATA_PORT_LOW  0x1D1
 #define DATA_PORT_HIGH 0x1D2
 #define PICOGUS_PROTOCOL_VER 2
+#endif
+
 static bool control_active = false;
 static uint8_t sel_reg = 0;
 static uint16_t cur_data = 0;


### PR DESCRIPTION
I want to preface this with a warning: web design is my passion!! Just kidding. But I'm not a very good programmer, so you are more than welcome to take my approach and re-implement in a different fashion.

I changed the PicoGUS firmware so that the MPU runs on a separate set of control/data addresses and added functionality into pgusinit so that you can interact with the firmware. The end result is I can now use the MPU firmware on one PicoGUS and then use a second card for the other various firmwares.

In pgusinit I opted to move from definitions to a constant variable which can be flipped by specifying /m at runtime. This adds capability to include more alternate card locations as there's enough address space to support 5 firmwares in theory at the same time.