### PR TITLE
Implementation of multi-firmware for PicoGus.

### DIFF
--- a/pgusinit/README.md
+++ b/pgusinit/README.md
@@ -1,4 +1,4 @@
-# PicoGUSinit v2.1.0
+# PicoGUSinit v2.1.5
 
 PicoGUSinit (also called pgusinit, after the program's .exe file) detects and
 initializes a PicoGUS card. In GUS emulation mode, it should be used instead of
@@ -31,6 +31,9 @@ settings. Options may be given for other settings:
 * `/v x` - sets wavetable header volume to x percent (PicoGUS 2.0 boards only).
   Available in all modes in case you want to use the wavetable header as an aux
   input (for example for an internal CD-ROM drive).
+* `/m x [d]` - changes operation mode (reboots card to x firmware, only if 
+   pg-multi.uf2 is flashed) for x: (1=gus, 2=sb, 3=mpu, 4=tandy, 5=cms, 6=joy)
+   the optional parameter 'd' makes the selected mode permanent at system boot
 
 Firmware files that come with the releases:
 
@@ -41,6 +44,8 @@ Firmware files that come with the releases:
 * `pg-cms.uf2` - CMS/Game Blaster emulation
 * `pg-joyex.uf2` - Joystick exclusive mode (doesn't emulate any sound cards,
   just the game port)
+* `pg-multi.uf2` - Multi-firmware. Contains all 6 firmwares in one. To be used
+  with /m x option in pgusinit to change mode.
 
 ### GUS emulation mode
 

--- a/pgusinit/pgusinit.c
+++ b/pgusinit/pgusinit.c
@@ -32,7 +32,7 @@ typedef enum {
 } card_mode_t;
 
 void banner(void) {
-    printf("PicoGUSinit v2.1.0 (c) 2024 Ian Scott - licensed under the GNU GPL v2\n\n");
+    printf("PicoGUSinit v2.1.6 (c) 2024 Ian Scott - licensed under the GNU GPL v2\n\n");
 }
 
 const char* usage_by_card[] = {
@@ -50,7 +50,7 @@ void usage(char *argv0, card_mode_t mode) {
     // Max line length @ 80 chars:
     //              "................................................................................\n"
     fprintf(stderr, "Usage:\n");
-    fprintf(stderr, "  %s [/?] | [/f fw.uf2]", argv0);
+    fprintf(stderr, "  %s [/?] | [/f fw.uf2] | [/m x [d]]", argv0);
     if (mode <= CMS_MODE) {
         fprintf(stderr, " | [/j] %s", usage_by_card[mode]);
     }
@@ -58,8 +58,11 @@ void usage(char *argv0, card_mode_t mode) {
     fprintf(stderr, "    /?        - show this message\n");
     fprintf(stderr, "    /f fw.uf2 - program the PicoGUS with the firmware file fw.uf2\n");
     fprintf(stderr, "    /j        - enable USB joystick support\n");
-    fprintf(stderr, "    /v x      - set the volume of the wavetable header. Scale 0-100, Default: 100\n");
+    fprintf(stderr, "    /v x      - set volume of the wavetable header. Scale 0-100, Default: 100\n");
     fprintf(stderr, "                (for PicoGUS v2.0 boards only)\n");
+    fprintf(stderr, "    /m x [d]  - change card mode to x (1=gus,2=sb,3=mpu,4=tandy,5=cms,6=joy)\n");
+    fprintf(stderr, "                the optional parameter 'd' makes the mode permanent at boot\n");
+    fprintf(stderr, "                (Only if pg-multi.uf2 is flashed)\n");
     if (mode > GUS_MODE && mode < JOYSTICK_ONLY_MODE) {
         fprintf(stderr, "Sound Blaster/AdLib, MPU-401, Tandy, CMS modes only:\n");
         fprintf(stderr, "    /p x - set the (hex) base port address of the emulated card. Defaults:\n");
@@ -170,13 +173,44 @@ void print_firmware_string(void) {
     printf("Firmware version: %s\n", firmware_string);
 }
 
+
 bool wait_for_read(uint8_t value) {
-    for (uint32_t i = 0; i < 1000000; ++i) {
+    for (uint32_t i = 0; i < 6000000; ++i) {    // Up to 6000000, for bigger fws like pg-multi.uf2, waiting for flash erase. If not, timeout and error.
         if (inp(DATA_PORT_HIGH) == value) {
             return true;
         }
     }
     return false;
+}
+
+// For multifw
+int reboot_to_firmware(uint8_t value, int mode) {
+
+    const char *fwnames[6];
+    fwnames[0] = "GUS";
+    fwnames[1] = "SB";
+    fwnames[2] = "MPU";
+    fwnames[3] = "TANDY";
+    fwnames[4] = "CMS";
+    fwnames[5] = "JOY";
+
+    outp(CONTROL_PORT, 0xCC); // Knock on the door...
+
+    outp(CONTROL_PORT, 0xE0); // Select firmware selection register
+    outpw(DATA_PORT_LOW, (0x0000 + value + (mode << 8))); // Send firmware number and permanent flag
+
+    printf("\nMode change requested. Rebooting to fw: %d (%s)...\n", value, fwnames[value-1]);
+    if (mode)
+            printf("%s mode selected as permanent on system boot.\n", fwnames[value-1]);
+
+    // Wait for card to reboot to new firmware
+    if (!wait_for_read(0xDD)) {
+        fprintf(stderr, "ERROR: card is not alive after rebooting to new firmware\n");
+        return 99;
+    }
+    printf("PicoGUS detected: ");
+    print_firmware_string();
+    return 0;
 }
 
 int write_firmware(const char* fw_filename, uint8_t protocol) {
@@ -244,7 +278,7 @@ int write_firmware(const char* fw_filename, uint8_t protocol) {
                 // up waiting on IOCHRDY and release the ISA bus after a certain amount of time before
                 // the flash operation is finished. This is an extra delay to work around this issue.
                 if (i == 0) { // first block takes longer due to flash erase
-                    delay(500);
+                    delay(5000);
                 } else {
                     delay(25);
                 }
@@ -293,6 +327,8 @@ int main(int argc, char* argv[]) {
     uint8_t mpu_fakeallnotesoff = 0;
     uint8_t enable_joystick = 0;
     uint8_t adlib_wait = 0;
+    uint8_t fwnum = 7;
+    int pMode = 0;
 
     banner();
     // Get magic value from port on PicoGUS that is not on real GUS
@@ -318,6 +354,21 @@ int main(int argc, char* argv[]) {
             return 0;
         } else if (stricmp(argv[i], "/j") == 0) {
             enable_joystick = 1;
+        } else if (stricmp(argv[i], "/m") == 0) {               
+            if (i + 1 >= argc) {
+                usage(argv[0], mode);
+                return 255;
+            }
+            e = sscanf(argv[++i], "%hu", &fwnum);
+            if (e != 1 || fwnum < 1 || fwnum> 6) {
+                usage(argv[0], mode);
+                return 5;
+            }
+            if (argc >= i + 2) {
+                if (!stricmp(argv[++i], "d")) {
+                    pMode = 1;
+                }               
+            }
         } else if (stricmp(argv[i], "/4") == 0) {
             force_44k = 1;
         } else if (stricmp(argv[i], "/a") == 0) {
@@ -403,6 +454,10 @@ int main(int argc, char* argv[]) {
 
     if (fw_filename[0]) {
         return write_firmware(fw_filename, protocol_got);
+    }
+
+    if (fwnum < 7) {
+        return reboot_to_firmware(fwnum, pMode);
     }
 
     outp(CONTROL_PORT, 0xf0); // Select hardware type register

--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -2,8 +2,7 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 17)
+
 
 # Initialise pico_sdk from installed location
 # (note this can come from environment, CMake cache etc)
@@ -13,27 +12,36 @@ set(CMAKE_CXX_STANDARD 17)
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)
-include(pico_extras_import.cmake)
 
 project(picogus
-    VERSION "1.2.0"
+    VERSION "1.2.6"
     LANGUAGES C CXX ASM
 )
 
+if( NOT (PROJECT_TYPE STREQUAL "BOOT"))
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+include(pico_extras_import.cmake)
+
+
 set(PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_LIST_DIR})
 set(PICO_BOARD picogus2)
-
-
-
-#set(PICO_DEOPTIMIZED_DEBUG "1")
-#set(CMAKE_BUILD_TYPE "Debug")
-set(CMAKE_BUILD_TYPE "Release")
 set(PICO_COPY_TO_RAM 1)
-#set(SKIP_PICO_MALLOC 1)
 
 # Tell the Pico SDK to use our local tinyusb instead of the one included in the SDK
 # This is needed to support tusb_xinput
 set(PICO_TINYUSB_PATH ${CMAKE_CURRENT_LIST_DIR}/tinyusb)
+
+endif() #NOT BOOT
+
+#set(PICO_DEOPTIMIZED_DEBUG "1")
+#set(CMAKE_BUILD_TYPE "Debug")
+set(CMAKE_BUILD_TYPE "Release")
+#set(SKIP_PICO_MALLOC 1)
+
+
 
 if(NOT PROJECT_TYPE)
     set(PROJECT_TYPE "GUS")
@@ -42,6 +50,30 @@ endif()
 
 # Initialise the Raspberry Pi Pico SDK
 pico_sdk_init()
+
+################################################################################
+# Helper function
+function(set_linker_script TARGET script)
+    target_link_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    pico_set_linker_script(${TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/${script})
+
+    # Add dependencies on the 'included' linker scripts so that the target gets
+    # rebuilt if they are changed
+    pico_add_link_depend(${TARGET} ${CMAKE_CURRENT_SOURCE_DIR}/${script})
+endfunction()
+
+if(PROJECT_TYPE STREQUAL "BOOT")
+
+add_executable(bootloader)
+target_sources(bootloader PRIVATE bootloader.c)
+target_link_libraries(bootloader PRIVATE pico_stdlib hardware_flash pico_multicore)
+pico_add_extra_outputs(bootloader)
+set_linker_script(bootloader bootloader.ld)
+
+else()
+################################################################################
+
+set(USB_JOYSTICK 1) 
 
 if(USE_LTO)
     # Pico SDK must be patched to allow for LTO so it is not enabled by default.
@@ -115,6 +147,8 @@ if(PROJECT_TYPE STREQUAL "GUS")
     endif()
     pico_enable_stdio_usb(picogus 0)
     pico_enable_stdio_semihosting(picogus 0)
+
+    set_linker_script(picogus firmware1.ld)
 endif()
 
 if(PROJECT_TYPE STREQUAL "SB")
@@ -138,6 +172,8 @@ if(PROJECT_TYPE STREQUAL "SB")
     pico_enable_stdio_uart(picogus 1)
     pico_enable_stdio_usb(picogus 0)
     pico_enable_stdio_semihosting(picogus 0)
+
+    set_linker_script(picogus firmware2.ld)
 endif()
 
 if(PROJECT_TYPE STREQUAL "MPU")
@@ -159,6 +195,8 @@ if(PROJECT_TYPE STREQUAL "MPU")
         pico_enable_stdio_usb(picogus 1)
     endif()
     pico_enable_stdio_semihosting(picogus 0)
+
+    set_linker_script(picogus firmware3.ld)
 endif()
 
 if(PROJECT_TYPE STREQUAL "TANDY")
@@ -175,6 +213,8 @@ if(PROJECT_TYPE STREQUAL "TANDY")
     pico_enable_stdio_uart(picogus 1)
     pico_enable_stdio_usb(picogus 0)
     pico_enable_stdio_semihosting(picogus 0)
+
+    set_linker_script(picogus firmware4.ld)
 endif()
 
 if(PROJECT_TYPE STREQUAL "CMS")
@@ -193,6 +233,8 @@ if(PROJECT_TYPE STREQUAL "CMS")
     pico_enable_stdio_uart(picogus 1)
     pico_enable_stdio_usb(picogus 0)
     pico_enable_stdio_semihosting(picogus 0)
+
+    set_linker_script(picogus firmware5.ld)
 endif()
 
 if(PROJECT_TYPE STREQUAL "JOY")
@@ -208,6 +250,8 @@ if(PROJECT_TYPE STREQUAL "JOY")
      pico_enable_stdio_uart(picogus 1)
      pico_enable_stdio_usb(picogus 0)
      pico_enable_stdio_semihosting(picogus 0)
+
+    set_linker_script(picogus firmware6.ld)
 endif()
 
 if(USB_JOYSTICK)
@@ -256,3 +300,5 @@ add_custom_target(
     DEPENDS picogus
     COMMAND openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg -c "adapter speed 5000\; program picogus.elf verify reset exit"
 )
+
+endif()  # endif BOOTLOADER

--- a/sw/bootloader.c
+++ b/sw/bootloader.c
@@ -1,0 +1,74 @@
+// By Jeroen Taverne
+// New features and mods by smymm
+
+#include "pico/stdlib.h"
+#include "hardware/structs/watchdog.h"
+#include <hardware/flash.h>
+#include "pico/multicore.h"
+#include "flash_firmware.h"
+
+static uint32_t sStart = 0;
+static const uint32_t permOffset = (2048 * 1024) - FLASH_PAGE_SIZE;   //  last page of a 2M flash (adjust for other flash sizes if needed)
+static const uint32_t offset[NR_OF_FIRMWARES] = {FLASH_FIRMWARE1, FLASH_FIRMWARE2, FLASH_FIRMWARE3, FLASH_FIRMWARE4, FLASH_FIRMWARE5, FLASH_FIRMWARE6};
+
+uint8_t read_permMode(void)
+{
+    const uint8_t *pMode = (const uint8_t *) (XIP_BASE + permOffset);
+    uint8_t pModeByte = *pMode;
+
+    if (pModeByte >= 1 && pModeByte <= NR_OF_FIRMWARES)
+        return (pModeByte - 1);
+    else
+        return 0;   // No valid value, boot 1st fw.
+}
+
+void write_permMode(uint8_t pModeFw)  // warning!! erasing last 4kb sector of the flash, and writing last page
+{
+    uint8_t data[FLASH_PAGE_SIZE] = {0};
+
+    data[0] = pModeFw;
+
+    uint32_t ints = save_and_disable_interrupts();
+    flash_range_erase((permOffset + FLASH_PAGE_SIZE - FLASH_SECTOR_SIZE), FLASH_SECTOR_SIZE);    // last sector
+    restore_interrupts(ints);
+    sleep_ms(100);
+    ints = save_and_disable_interrupts();
+    flash_range_program(permOffset, data, FLASH_PAGE_SIZE);     // last page
+    restore_interrupts(ints);
+}
+
+int main(void)
+{
+	uint8_t firmware_nr = (uint8_t) (0x000000FF & watchdog_hw->scratch[3]);
+    uint8_t firmware_mode = (uint8_t) (0x000000FF & (watchdog_hw->scratch[3] >> 8));
+
+	if (firmware_nr > NR_OF_FIRMWARES) {
+		firmware_nr = 0;
+	}
+
+    if (firmware_mode == 1 && firmware_nr > 0) // Perm mode requested. Write fw num to flash.
+        write_permMode(firmware_nr);
+
+    if (firmware_nr == 0)   // Try to boot from permanent storage if no change requested / cold boot / bad value
+    {
+        sStart = offset[read_permMode()] + XIP_BASE;
+    } else {    // Mode change requested by pgusinit
+    	sStart = offset[firmware_nr-1] + XIP_BASE;
+    }
+
+	// Jump to application
+	asm volatile
+	(
+	    "mov r0, %[start]\n"
+	    "ldr r1, =%[vtable]\n"
+	    "str r0, [r1]\n"
+	    "ldmia r0, {r0, r1}\n"
+	    "msr msp, r0\n"
+	    "bx r1\n"
+	    :
+	    : [start] "r" (sStart + 0x100), [vtable] "X" (PPB_BASE + M0PLUS_VTOR_OFFSET)
+	    :
+	);
+
+	return 0;
+}

--- a/sw/bootloader.ld
+++ b/sw/bootloader.ld
@@ -1,0 +1,251 @@
+/* Based on GCC ARM embedded samples.
+   Defines the following symbols for use by code:
+    __exidx_start
+    __exidx_end
+    __etext
+    __data_start__
+    __preinit_array_start
+    __preinit_array_end
+    __init_array_start
+    __init_array_end
+    __fini_array_start
+    __fini_array_end
+    __data_end__
+    __bss_start__
+    __bss_end__
+    __end__
+    end
+    __HeapLimit
+    __StackLimit
+    __StackTop
+    __stack (== StackTop)
+*/
+
+MEMORY
+{
+    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 32k
+    RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 256k
+    SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
+    SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
+}
+
+ENTRY(_entry_point)
+
+SECTIONS
+{
+    /* Second stage bootloader is prepended to the image. It must be 256 bytes big
+       and checksummed. It is usually built by the boot_stage2 target
+       in the Raspberry Pi Pico SDK
+    */
+
+    .flash_begin : {
+        __flash_binary_start = .;
+    } > FLASH
+
+    .boot2 : {
+        __boot2_start__ = .;
+        KEEP (*(.boot2))
+        __boot2_end__ = .;
+    } > FLASH
+
+    ASSERT(__boot2_end__ - __boot2_start__ == 256,
+        "ERROR: Pico second stage bootloader must be 256 bytes in size")
+
+    /* The second stage will always enter the image at the start of .text.
+       The debugger will use the ELF entry point, which is the _entry_point
+       symbol if present, otherwise defaults to start of .text.
+       This can be used to transfer control back to the bootrom on debugger
+       launches only, to perform proper flash setup.
+    */
+
+    .text : {
+        __logical_binary_start = .;
+        KEEP (*(.vectors))
+        KEEP (*(.binary_info_header))
+        __binary_info_header_end = .;
+        KEEP (*(.reset))
+        /* TODO revisit this now memset/memcpy/float in ROM */
+        /* bit of a hack right now to exclude all floating point and time critical (e.g. memset, memcpy) code from
+         * FLASH ... we will include any thing excluded here in .data below by default */
+        *(.init)
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a:) .text*)
+        *(.fini)
+        /* Pull all c'tors into .text */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+        /* Followed by destructors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.eh_frame*)
+        . = ALIGN(4);
+    } > FLASH
+
+    .rodata : {
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a:) .rodata*)
+        . = ALIGN(4);
+        *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
+        . = ALIGN(4);
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    /* Machine inspectable binary information */
+    . = ALIGN(4);
+    __binary_info_start = .;
+    .binary_info :
+    {
+        KEEP(*(.binary_info.keep.*))
+        *(.binary_info.*)
+    } > FLASH
+    __binary_info_end = .;
+    . = ALIGN(4);
+
+   .ram_vector_table (NOLOAD): {
+        *(.ram_vector_table)
+    } > RAM
+
+    .data : {
+        __data_start__ = .;
+        *(vtable)
+
+        *(.time_critical*)
+
+        /* remaining .text and .rodata; i.e. stuff we exclude above because we want it in RAM */
+        *(.text*)
+        . = ALIGN(4);
+        *(.rodata*)
+        . = ALIGN(4);
+
+        *(.data*)
+
+        . = ALIGN(4);
+        *(.after_data.*)
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__mutex_array_start = .);
+        KEEP(*(SORT(.mutex_array.*)))
+        KEEP(*(.mutex_array))
+        PROVIDE_HIDDEN (__mutex_array_end = .);
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(SORT(.preinit_array.*)))
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        *(SORT(.fini_array.*))
+        *(.fini_array)
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        *(.jcr)
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM AT> FLASH
+    /* __etext is (for backwards compatibility) the name of the .data init source pointer (...) */
+    __etext = LOADADDR(.data);
+
+    .uninitialized_data (NOLOAD): {
+        . = ALIGN(4);
+        *(.uninitialized_data*)
+    } > RAM
+
+    /* Start and end symbols must be word-aligned */
+    .scratch_x : {
+        __scratch_x_start__ = .;
+        *(.scratch_x.*)
+        . = ALIGN(4);
+        __scratch_x_end__ = .;
+    } > SCRATCH_X AT > FLASH
+    __scratch_x_source__ = LOADADDR(.scratch_x);
+
+    .scratch_y : {
+        __scratch_y_start__ = .;
+        *(.scratch_y.*)
+        . = ALIGN(4);
+        __scratch_y_end__ = .;
+    } > SCRATCH_Y AT > FLASH
+    __scratch_y_source__ = LOADADDR(.scratch_y);
+
+    .bss  : {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.bss*)))
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    .heap (NOLOAD):
+    {
+        __end__ = .;
+        end = __end__;
+        KEEP(*(.heap*))
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack*_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later
+     *
+     * stack1 section may be empty/missing if platform_launch_core1 is not used */
+
+    /* by default we put core 0 stack at the end of scratch Y, so that if core 1
+     * stack is not used then all of SCRATCH_X is free.
+     */
+    .stack1_dummy (NOLOAD):
+    {
+        *(.stack1*)
+    } > SCRATCH_X
+    .stack_dummy (NOLOAD):
+    {
+        KEEP(*(.stack*))
+    } > SCRATCH_Y
+
+    .flash_end : {
+        PROVIDE(__flash_binary_end = .);
+    } > FLASH
+
+    /* stack limit is poorly named, but historically is maximum heap ptr */
+    __StackLimit = ORIGIN(RAM) + LENGTH(RAM);
+    __StackOneTop = ORIGIN(SCRATCH_X) + LENGTH(SCRATCH_X);
+    __StackTop = ORIGIN(SCRATCH_Y) + LENGTH(SCRATCH_Y);
+    __StackOneBottom = __StackOneTop - SIZEOF(.stack1_dummy);
+    __StackBottom = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed")
+
+    ASSERT( __binary_info_header_end - __logical_binary_start <= 256, "Binary info must be in first 256 bytes of the binary")
+    /* todo assert on extra code */
+}
+

--- a/sw/firmware1.ld
+++ b/sw/firmware1.ld
@@ -1,0 +1,6 @@
+MEMORY
+{
+    FLASH(rx) : ORIGIN = 0x10008000, LENGTH = 256k
+}
+
+INCLUDE fw_memmap_c2ram.ld

--- a/sw/firmware2.ld
+++ b/sw/firmware2.ld
@@ -1,0 +1,6 @@
+MEMORY
+{
+    FLASH(rx) : ORIGIN = 0x10040000, LENGTH = 256k
+}
+
+INCLUDE fw_memmap_c2ram.ld

--- a/sw/firmware3.ld
+++ b/sw/firmware3.ld
@@ -1,0 +1,6 @@
+MEMORY
+{
+    FLASH(rx) : ORIGIN = 0x10080000, LENGTH = 256k
+}
+
+INCLUDE fw_memmap_c2ram.ld

--- a/sw/firmware4.ld
+++ b/sw/firmware4.ld
@@ -1,0 +1,6 @@
+MEMORY
+{
+    FLASH(rx) : ORIGIN = 0x100c0000, LENGTH = 256k
+}
+
+INCLUDE fw_memmap_c2ram.ld

--- a/sw/firmware5.ld
+++ b/sw/firmware5.ld
@@ -1,0 +1,6 @@
+MEMORY
+{
+    FLASH(rx) : ORIGIN = 0x10100000, LENGTH = 256k
+}
+
+INCLUDE fw_memmap_c2ram.ld

--- a/sw/firmware6.ld
+++ b/sw/firmware6.ld
@@ -1,0 +1,6 @@
+MEMORY
+{
+    FLASH(rx) : ORIGIN = 0x10140000, LENGTH = 256k
+}
+
+INCLUDE fw_memmap_c2ram.ld

--- a/sw/flash_firmware.h
+++ b/sw/flash_firmware.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// By Jeroen Taverne
+// New features and mods by smymm
+
+// Make sure the FLASH addresses match the .ld files!!!
+// ld files for picogus firmwares/modes are based on memmap_copy_to_ram.ld as they run with set(PICO_COPY_TO_RAM 1)
+
+#define NR_OF_FIRMWARES 6
+#define FLASH_FIRMWARE1 0x00008000
+#define FLASH_FIRMWARE2 0x00040000
+#define FLASH_FIRMWARE3 0x00080000
+#define FLASH_FIRMWARE4 0x000c0000
+#define FLASH_FIRMWARE5 0x00100000
+#define FLASH_FIRMWARE6 0x00140000

--- a/sw/fw_memmap_c2ram.ld
+++ b/sw/fw_memmap_c2ram.ld
@@ -1,0 +1,252 @@
+/* Based on GCC ARM embedded samples.
+   Defines the following symbols for use by code:
+    __exidx_start
+    __exidx_end
+    __etext
+    __data_start__
+    __preinit_array_start
+    __preinit_array_end
+    __init_array_start
+    __init_array_end
+    __fini_array_start
+    __fini_array_end
+    __data_end__
+    __bss_start__
+    __bss_end__
+    __end__
+    end
+    __HeapLimit
+    __StackLimit
+    __StackTop
+    __stack (== StackTop)
+*/
+
+MEMORY
+{
+    RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 256k
+    SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
+    SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
+}
+
+ENTRY(_entry_point)
+
+SECTIONS
+{
+    /* Second stage bootloader is prepended to the image. It must be 256 bytes big
+       and checksummed. It is usually built by the boot_stage2 target
+       in the Raspberry Pi Pico SDK
+    */
+
+    .flash_begin : {
+        __flash_binary_start = .;
+    } > FLASH
+
+    .boot2 : {
+        __boot2_start__ = .;
+        KEEP (*(.boot2))
+        __boot2_end__ = .;
+    } > FLASH
+
+    ASSERT(__boot2_end__ - __boot2_start__ == 256,
+        "ERROR: Pico second stage bootloader must be 256 bytes in size")
+
+    /* The second stage will always enter the image at the start of .text.
+       The debugger will use the ELF entry point, which is the _entry_point
+       symbol if present, otherwise defaults to start of .text.
+       This can be used to transfer control back to the bootrom on debugger
+       launches only, to perform proper flash setup.
+    */
+
+    .flashtext : {
+        __logical_binary_start = .;
+        KEEP (*(.vectors))
+        KEEP (*(.binary_info_header))
+        __binary_info_header_end = .;
+        KEEP (*(.reset))
+    }
+
+    .rodata : {
+        /* segments not marked as .flashdata are instead pulled into .data (in RAM) to avoid accidental flash accesses */
+        *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
+        . = ALIGN(4);
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    /* Machine inspectable binary information */
+    . = ALIGN(4);
+    __binary_info_start = .;
+    .binary_info :
+    {
+        KEEP(*(.binary_info.keep.*))
+        *(.binary_info.*)
+    } > FLASH
+    __binary_info_end = .;
+    . = ALIGN(4);
+
+    /* Vector table goes first in RAM, to avoid large alignment hole */
+   .ram_vector_table (COPY): {
+        *(.ram_vector_table)
+    } > RAM
+
+    .text : {
+        __ram_text_start__ = .;
+        *(.init)
+        *(.text*)
+        *(.fini)
+        /* Pull all c'tors into .text */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+        /* Followed by destructors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.eh_frame*)
+        . = ALIGN(4);
+        __ram_text_end__ = .;
+    } > RAM AT> FLASH
+    __ram_text_source__ = LOADADDR(.text);
+
+
+    .data : {
+        __data_start__ = .;
+        *(vtable)
+
+        *(.time_critical*)
+
+        . = ALIGN(4);
+        *(.rodata*)
+        . = ALIGN(4);
+
+        *(.data*)
+
+        . = ALIGN(4);
+        *(.after_data.*)
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__mutex_array_start = .);
+        KEEP(*(SORT(.mutex_array.*)))
+        KEEP(*(.mutex_array))
+        PROVIDE_HIDDEN (__mutex_array_end = .);
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(SORT(.preinit_array.*)))
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        *(SORT(.fini_array.*))
+        *(.fini_array)
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        *(.jcr)
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+    } > RAM AT> FLASH
+    /* __etext is the name of the .data init source pointer (...) */
+    __etext = LOADADDR(.data);
+
+    .uninitialized_data (COPY): {
+        . = ALIGN(4);
+        *(.uninitialized_data*)
+    } > RAM
+
+    /* Start and end symbols must be word-aligned */
+    .scratch_x : {
+        __scratch_x_start__ = .;
+        *(.scratch_x.*)
+        . = ALIGN(4);
+        __scratch_x_end__ = .;
+    } > SCRATCH_X AT > FLASH
+    __scratch_x_source__ = LOADADDR(.scratch_x);
+
+    .scratch_y : {
+        __scratch_y_start__ = .;
+        *(.scratch_y.*)
+        . = ALIGN(4);
+        __scratch_y_end__ = .;
+    } > SCRATCH_Y AT > FLASH
+    __scratch_y_source__ = LOADADDR(.scratch_y);
+
+    .bss  : {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.bss*)))
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    .heap (COPY):
+    {
+        __end__ = .;
+        end = __end__;
+        *(.heap*)
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack*_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later
+     *
+     * stack1 section may be empty/missing if platform_launch_core1 is not used */
+
+    /* by default we put core 0 stack at the end of scratch Y, so that if core 1
+     * stack is not used then all of SCRATCH_X is free.
+     */
+    .stack1_dummy (COPY):
+    {
+        *(.stack1*)
+    } > SCRATCH_X
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > SCRATCH_Y
+
+    .flash_end : {
+        __flash_binary_end = .;
+    } > FLASH
+
+    /* stack limit is poorly named, but historically is maximum heap ptr */
+    __StackLimit = ORIGIN(RAM) + LENGTH(RAM);
+    __StackOneTop = ORIGIN(SCRATCH_X) + LENGTH(SCRATCH_X);
+    __StackTop = ORIGIN(SCRATCH_Y) + LENGTH(SCRATCH_Y);
+    __StackOneBottom = __StackOneTop - SIZEOF(.stack1_dummy);
+    __StackBottom = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed")
+
+    ASSERT( __binary_info_header_end - __logical_binary_start <= 256, "Binary info must be in first 256 bytes of the binary")
+    /* todo assert on extra code */
+}
+

--- a/sw/gus-x.cpp
+++ b/sw/gus-x.cpp
@@ -1599,8 +1599,8 @@ __force_inline void GUS_StartDMA() {
 }
 
 
-extern uint32_t __scratch_x("my_sub_section") (GUS_CallBack)(Bitu max_len, int16_t* play_buffer) {
-// extern uint32_t GUS_CallBack(Bitu max_len, int16_t* play_buffer) {
+//extern uint32_t __scratch_x("my_sub_section") (GUS_CallBack)(Bitu max_len, int16_t* play_buffer) {  //testsam
+extern uint32_t GUS_CallBack(Bitu max_len, int16_t* play_buffer) {
     static int32_t accum[2];
 #ifdef SCALE_22K_TO_44K
     static int32_t prev_accum[2];

--- a/sw/uf2.h
+++ b/sw/uf2.h
@@ -1,0 +1,47 @@
+/*
+* Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _BOOT_UF2_H
+#define _BOOT_UF2_H
+
+#include <stdint.h>
+#include <assert.h>
+
+/** \file uf2.h
+*  \defgroup boot_uf2 boot_uf2
+*
+* Header file for the UF2 format supported by an RP2040 in BOOTSEL mode.
+*/
+
+#define UF2_MAGIC_START0 0x0A324655u
+#define UF2_MAGIC_START1 0x9E5D5157u
+#define UF2_MAGIC_END    0x0AB16F30u
+
+#define UF2_FLAG_NOT_MAIN_FLASH     0x00000001u
+#define UF2_FLAG_FILE_CONTAINER     0x00001000u
+#define UF2_FLAG_FAMILY_ID_PRESENT  0x00002000u
+#define UF2_FLAG_MD5_PRESENT        0x00004000u
+
+#define RP2040_FAMILY_ID 0xe48bff56
+
+struct uf2_block
+{
+	// 32 byte header
+	uint32_t magic_start0;
+	uint32_t magic_start1;
+	uint32_t flags;
+	uint32_t target_addr;
+	uint32_t payload_size;
+	uint32_t block_no;
+	uint32_t num_blocks;
+	uint32_t file_size; // or familyID;
+	uint8_t  data[476];
+	uint32_t magic_end;
+};
+
+static_assert(sizeof(struct uf2_block) == 512, "uf2_block not sector sized");
+
+#endif

--- a/sw/uf2create.c
+++ b/sw/uf2create.c
@@ -1,0 +1,90 @@
+// By Jeroen Taverne
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "uf2.h"
+#include "flash_firmware.h"
+
+#define FLASH_SIZE 0x200000
+#define PAYLOAD_SIZE 0x100
+#define INPUT_FILES (NR_OF_FIRMWARES + 1)
+
+int main(int argc, char *argv[])
+{
+	int total_size = 0;
+	static uint8_t flashbuffer[FLASH_SIZE];
+	uint32_t offset[INPUT_FILES] = {0, FLASH_FIRMWARE1, FLASH_FIRMWARE2, FLASH_FIRMWARE3, FLASH_FIRMWARE4, FLASH_FIRMWARE5, FLASH_FIRMWARE6};
+	struct uf2_block uf2;
+
+	FILE *f_input, *f_output;
+
+	if (argc != INPUT_FILES+2) {
+		fprintf(stderr, "Usage: %s <%d binary input files> <UF2 output file>\n", argv[0], INPUT_FILES);
+		return -1;
+	}
+
+	memset(flashbuffer, 0xff, FLASH_SIZE);
+
+	for (int i=0; i<INPUT_FILES; i++) {
+		int arg = i + 1;
+		printf("Opening %s for read\n", argv[arg]);
+		f_input = fopen(argv[arg], "rb");
+		if (f_input == NULL) {
+			fprintf(stderr, "%s: can't open %s for reading\n", argv[0], argv[arg]);
+			return -1;
+		}
+		fseek(f_input, 0L, SEEK_END);
+		uint32_t size = ftell(f_input);
+		fseek(f_input, 0L, SEEK_SET);
+		if ((size + offset[i]) > FLASH_SIZE) {
+			fprintf(stderr, "Too big to fit in FLASH!\n");
+			return -1;
+		}
+		for (int j=0; j<size; j++) {
+			if (flashbuffer[offset[i] + j] != 0xff) {
+				fprintf(stderr, "Files will overlap in FLASH!\n");
+				return -1;
+			}
+		}
+		fread(&flashbuffer[offset[i]], size, 1, f_input);
+		fclose(f_input);
+		if (size > 0) {
+			size += offset[i];
+			if (size > total_size) {
+				total_size = size;
+			}
+		}
+	}
+
+	int arg = INPUT_FILES + 1;
+	printf("Opening %s for write\n", argv[arg]);
+	f_output = fopen(argv[arg], "wb");
+
+	uf2.magic_start0 = UF2_MAGIC_START0;
+	uf2.magic_start1 = UF2_MAGIC_START1;
+	uf2.flags = UF2_FLAG_FAMILY_ID_PRESENT;
+	uf2.file_size = RP2040_FAMILY_ID;
+	uf2.payload_size = PAYLOAD_SIZE;
+	uf2.block_no = 0;
+	uf2.num_blocks = (total_size + PAYLOAD_SIZE - 1) / PAYLOAD_SIZE;
+	memset(uf2.data, 0, sizeof(uf2.data));
+	uf2.magic_end = UF2_MAGIC_END;
+
+	int index = 0;
+	while (index < total_size) {
+		uf2.target_addr = 0x10000000 + index;
+		memcpy(uf2.data, &flashbuffer[index], PAYLOAD_SIZE);
+		fwrite(&uf2, sizeof(uf2), 1, f_output);
+		uf2.block_no++;
+		index += PAYLOAD_SIZE;
+	}
+
+	fclose(f_output);
+
+	printf("Done!\n");
+
+	return 0;
+}


### PR DESCRIPTION
Flash only one file: pg-multi.uf2 only one time. It contains all firmwares (6 at this moment). You can change between them in DOS: 

New usage for this version:

    pgusinit   /m x [d]  - change card mode to x (1=gus,2=sb,3=mpu,4=tandy,5=cms,6=joy)
               the optional parameter 'd' makes the mode permanent at boot
               (Only if pg-multi.uf2 is flashed)

Examples of use:

    You have default mode as GUS mode on boot, want to change mode to SB, but only temporarily:

    pgusinit /m 2

    You want to change the default (permanent) mode of the card to SB mode, and the next system cold boots / hard resets / power off you want to stay in SB mode without using pgusinit:

   pgusinit /m 2 d