### PR TITLE
Update emu8950.c

### DIFF
--- a/sw/opl/emu8950.c
+++ b/sw/opl/emu8950.c
@@ -868,7 +868,10 @@ static INLINE void calc_envelope(OPL_SLOT *slot, uint16_t eg_counter, uint8_t te
     if (slot->eg_state == ATTACK) {
         if (0 < slot->eg_out && slot->eg_rate_h > 0 && (eg_counter & mask) == 0) {
             step = lookup_attack_step(slot, eg_counter);
-            slot->eg_out += (~slot->eg_out * step) >> 3;
+            if(step)
+                slot->eg_out += (~slot->eg_out * step) >> 3;
+            else
+                slot->eg_out = 0;     // Switch immediately to decay for eg rate 0
         }
     } else {
         if (slot->eg_rate_h > 0 && (eg_counter & mask) == 0) {
@@ -1411,7 +1414,10 @@ uint32_t __not_in_flash_func(slot_mod_linear)(OPL *opl, OPL_SLOT *slot, uint32_t
             uint16_t mask = (1 << slot->eg_shift) - 1;
             if (0 < slot->eg_out && slot->eg_rate_h > 0 && (eg_counter & mask) == 0) {
                 uint8_t step = lookup_attack_step(slot, eg_counter);
-                slot->eg_out += (~slot->eg_out * step) >> 3;
+                if (step) 
+                    slot->eg_out += (~slot->eg_out * step) >> 3;
+                else
+                    slot->eg_out = 0;
             }
             if (slot->eg_out == 0) {
                 slot->eg_state = DECAY;
@@ -1513,7 +1519,10 @@ uint32_t __not_in_flash_func(slot_car_linear_alg1)(OPL *opl, OPL_SLOT *slot, uin
             uint16_t mask = (1 << slot->eg_shift) - 1;
             if (0 < slot->eg_out && slot->eg_rate_h > 0 && (eg_counter & mask) == 0) {
                 uint8_t step = lookup_attack_step(slot, eg_counter);
-                slot->eg_out += (~slot->eg_out * step) >> 3;
+                if (step)
+                    slot->eg_out += (~slot->eg_out * step) >> 3;
+                else
+                    slot->eg_out = 0;
             }
             if (slot->eg_out == 0) {
                 slot->eg_state = DECAY;
@@ -1612,7 +1621,10 @@ uint32_t __not_in_flash_func(slot_car_linear_alg0)(OPL *opl, OPL_SLOT *slot, uin
             uint16_t mask = (1 << slot->eg_shift) - 1;
             if (0 < slot->eg_out && slot->eg_rate_h > 0 && (eg_counter & mask) == 0) {
                 uint8_t step = lookup_attack_step(slot, eg_counter);
-                slot->eg_out += (~slot->eg_out * step) >> 3;
+                if (step)
+                    slot->eg_out += (~slot->eg_out * step) >> 3;
+                else
+                    slot->eg_out = 0;
             }
             if (slot->eg_out == 0) {
                 slot->eg_state = DECAY;


### PR DESCRIPTION
Fix for https://github.com/polpo/picogus/issues/46
Attack step is 0 for eg_rate_h 15 causing envelop never switch to decay, causing some music missing notes in higher notes. For fix, step value 0 is treated as special case resetting eg_out to 0 which immediately switches envelop generator to decay.
