### PR TITLE
Volume Control

### DIFF
--- a/common/picogus.h
+++ b/common/picogus.h
@@ -88,6 +88,13 @@ static const char *modenames[8] = {
 #define MODE_CDNAME     0x65 // Get name of loaded CD image
 #define MODE_CDAUTOADV  0x66 // Set autoadvance for CD image on USB reinsert
 
+#define MODE_MAINVOL    0x70 // Main Volume
+#define MODE_OPLVOL     0x71 // Adlib volume
+#define MODE_SBVOL      0x72 // Sound Blaster volume
+#define MODE_CDVOL      0x73 // CD Audio Volume
+#define MODE_GUSVOL     0x74 // GUS Volume
+#define MODE_PSGVOL     0x75 // PSG Volume
+
 #define MODE_DEFAULTS   0xE0 // Select reset to defaults register
 #define MODE_SAVE       0xE1 // Select save settings register
 #define MODE_REBOOT     0xE2 // Select reboot register

--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -204,6 +204,7 @@ function(build_gus TARGET_NAME MULTIFW)
     config_target(${TARGET_NAME} ${MULTIFW})
     pico_set_program_name(${TARGET_NAME} "picogus-gus")
     target_sources(${TARGET_NAME} PRIVATE
+        volctrl.cpp
         gusplay.cpp
         isa_dma.c
     )
@@ -241,6 +242,7 @@ function(build_sb TARGET_NAME MULTIFW)
     config_target(${TARGET_NAME} ${MULTIFW})
     pico_set_program_name(${TARGET_NAME} "picogus-sb")
     target_sources(${TARGET_NAME} PRIVATE
+        volctrl.cpp
         sbdsp.cpp
         sbplay.cpp
         isa_dma.c
@@ -263,7 +265,10 @@ function(build_adlib TARGET_NAME MULTIFW)
     set(SOUND_OPL TRUE)
     config_target(${TARGET_NAME} ${MULTIFW})
     pico_set_program_name(${TARGET_NAME} "picogus-adlib")
-    target_sources(${TARGET_NAME} PRIVATE sbplay.cpp)    
+    target_sources(${TARGET_NAME} PRIVATE 
+        volctrl.cpp
+        sbplay.cpp
+    )    
 endfunction()
 
 ################################################################################
@@ -295,6 +300,7 @@ function(build_psg TARGET_NAME MULTIFW)
         SOUND_CMS=1
     )
     target_sources(${TARGET_NAME} PRIVATE
+        volctrl.cpp
         square/square.cpp
     )
     target_sources(${TARGET_NAME} PRIVATE psgplay.cpp)
@@ -312,7 +318,10 @@ function(build_usb TARGET_NAME MULTIFW)
     target_compile_definitions(${TARGET_NAME} PRIVATE
         USB_ONLY=1
     )
-    target_sources(${TARGET_NAME} PRIVATE usbplay.cpp)
+    target_sources(${TARGET_NAME} PRIVATE 
+        volctrl.cpp
+        usbplay.cpp
+    )
 endfunction()
 
 

--- a/sw/cdrom/cdrom.c
+++ b/sw/cdrom/cdrom.c
@@ -32,6 +32,7 @@
 #include "cdrom_error_msg.h"
 #include "pico/multicore.h"
 #include "hardware/structs/timer.h"
+#include "../volctrl.h"
 
 
 /* The addresses sent from the guest are absolute, ie. a LBA of 0 corresponds to a MSF of 00:00:00. Otherwise, the counter displayed by the guest is wrong:
@@ -399,7 +400,14 @@ uint32_t cdrom_audio_callback_simple(cdrom_t *dev, int16_t *buffer, uint32_t len
 
         /* printf("%u\n", samples_to_transfer); */
         // Add samples from sector buffer to FIFO
-        memcpy(buffer + samples_produced, &dev->current_sector_samples[dev->audio_sector_consumed_samples], samples_to_transfer * sizeof(int16_t));
+        //memcpy(buffer + samples_produced, &dev->current_sector_samples[dev->audio_sector_consumed_samples], samples_to_transfer * sizeof(int16_t));
+
+        for (uint32_t i = 0; i < samples_to_transfer; i++)
+        {
+            int32_t sample = dev->current_sector_samples[dev->audio_sector_consumed_samples + i];       
+            buffer[samples_produced + i] = (int16_t)scale_sample(sample, cd_audio_volume, 0);
+        }
+
         samples_produced += samples_to_transfer;
         dev->audio_sector_consumed_samples += samples_to_transfer;
     } // End while (fifo_level < len && ret)

--- a/sw/cdrom/cdrom.h
+++ b/sw/cdrom/cdrom.h
@@ -15,6 +15,7 @@
  *          Copyright 2016-2019 Miran Grca.
  *          Copyright (C) 2024 Kevin Moonlight
  *          Copyright (C) 2025 Ian Scott
+ *          Copyright (C) 2025 Daniel Arnold
  */
 
 #ifndef EMU_CDROM_H
@@ -60,7 +61,6 @@
 #define STAT_ERROR	    0x10
 #define STAT_DISK	    0x40
 #define STAT_TRAY	    0x80
-
 
 /* This is so that if/when this is changed to something else,
    changing this one define will be enough. */
@@ -201,6 +201,7 @@ typedef struct cdrom {
     int16_t *current_sector_samples;       // Convenience pointer: (int16_t*)audio_sector_buffer
     int audio_sector_total_samples;        // Samples available in current_sector_samples after a read
     int audio_sector_consumed_samples;     // Samples consumed from current_sector_samples
+
 #if USE_CD_AUDIO_FIFO
     audio_fifo_t audio_fifo;
 #endif
@@ -271,6 +272,9 @@ extern int find_cdrom_for_scsi_id(uint8_t scsi_id);
 
 extern void cdrom_close(void);
 extern void cdrom_global_init(void);
+
+extern int32_t cd_audio_volume; 
+extern void cdrom_set_volume_scale(uint8_t percent);
 
 #ifdef __cplusplus
 }

--- a/sw/flash_settings.c
+++ b/sw/flash_settings.c
@@ -77,6 +77,14 @@ static const Settings defaultSettings = {
     .MMB = {
         // Mindscape Music Board defaults to off because its port is so common
         .basePort = 0xffff
+    },
+    .Volume = {
+        .mainVol = 100,
+        .oplVol = 90,
+        .sbVol = 100,
+        .cdVol = 100,
+        .gusVol = 100,
+        .psgVol = 80
     }
 };
 

--- a/sw/flash_settings.h
+++ b/sw/flash_settings.h
@@ -80,6 +80,14 @@ typedef struct Settings {
     struct {
         uint16_t basePort;
     } MMB;
+    struct {
+        uint8_t mainVol;
+        uint8_t oplVol;
+        uint8_t sbVol;
+        uint8_t cdVol;
+        uint8_t gusVol;
+        uint8_t psgVol;
+    } Volume;
 } Settings;
 
 

--- a/sw/gus-x.cpp
+++ b/sw/gus-x.cpp
@@ -43,6 +43,7 @@ critical_section_t gus_crit;
 extern dma_inst_t dma_config;
 
 #include "clamp.h"
+#include "volctrl.h"
 
 using namespace std;
 
@@ -615,6 +616,7 @@ class GUSChannels {
 
             // Output stereo sample if DAC enable on
             // if ((GUS_reset_reg & 0x02/*DAC enable*/) == 0x02) {
+                tmpsamp = scale_sample(tmpsamp, gus_volume, 0);
                 stream[0] += tmpsamp * VolLeft;
                 stream[1] += tmpsamp * VolRight;
                 WaveUpdate();

--- a/sw/psgplay.cpp
+++ b/sw/psgplay.cpp
@@ -32,6 +32,7 @@
 #include "square/square.h"
 
 #include "cmd_buffers.h"
+#include "volctrl.h"
 
 #if SOUND_TANDY
 extern tandy_buffer_t tandy_buffer;
@@ -170,9 +171,9 @@ void play_psg() {
         cms.generator(0).generate_frames(buf, SAMPLES_PER_BUFFER);
         cms.generator(1).generate_frames(buf, SAMPLES_PER_BUFFER);
 #endif
-        for (int i = 0; i < SAMPLES_PER_BUFFER; ++i) {
-            samples[i << 1] = buf[i << 1] >> 1;
-            samples[(i << 1) + 1] = buf[(i << 1) + 1] >> 1;
+        for (int i = 0; i < SAMPLES_PER_BUFFER; ++i) {          
+            samples[i << 1] = scale_sample(buf[i << 1], psg_volume, 0);
+            samples[(i << 1) + 1] = scale_sample(buf[(i << 1) + 1], psg_volume, 0);
         }
         buffer->sample_count = SAMPLES_PER_BUFFER;
 

--- a/sw/volctrl.cpp
+++ b/sw/volctrl.cpp
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (C) 2025  Daniel Arnold
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+#include "flash_settings.h"
+#include "pico/stdlib.h"
+#include "volctrl.h"
+#include "clamp.h"
+#include "flash_settings.h"
+extern Settings settings;
+
+int32_t opl_volume = 0x10000; // default 1.0x volume
+int32_t sb_volume = 0x10000; // default 1.0x volume
+int32_t cd_audio_volume = 0x10000; // default 1.0x volume
+int32_t gus_volume = 0x10000; // default 1.0x volume
+int32_t psg_volume = 0x10000; // default 1.0x volume
+
+
+int32_t set_volume_scale (uint8_t percent) {
+     if (percent > 100)
+        percent = 100;
+
+    uint8_t delta = 100 - settings.Volume.mainVol;
+
+    int32_t volume = ((percent - delta) * 65536) / 100;
+    
+    if (percent < 1) 
+        volume = 0;
+
+    return volume;
+}
+
+int32_t scale_sample (int32_t sample, int32_t scale, int clamp) {
+    sample = (sample * scale) >> 16;
+
+    if (clamp)
+        clamp16(sample);
+
+    return sample;
+}
+
+void set_volume(uint16_t mode) {
+
+    switch (mode){
+        case MODE_MAINVOL:
+            set_volume(MODE_OPLVOL);
+            set_volume(MODE_SBVOL);
+            set_volume(MODE_CDVOL);
+            set_volume(MODE_GUSVOL);
+            set_volume(MODE_PSGVOL);
+            break;
+        case MODE_OPLVOL:
+            opl_volume = set_volume_scale(settings.Volume.oplVol);
+            break;
+        case MODE_SBVOL:
+            sb_volume = set_volume_scale(settings.Volume.sbVol);
+            break;
+        case MODE_CDVOL:
+            cd_audio_volume = set_volume_scale(settings.Volume.sbVol);
+            break;
+        case MODE_GUSVOL:
+            gus_volume = set_volume_scale(settings.Volume.gusVol);
+            break;
+        case MODE_PSGVOL:
+            psg_volume = set_volume_scale(settings.Volume.psgVol);
+            break;
+    }   
+}

--- a/sw/volctrl.h
+++ b/sw/volctrl.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2025  Daniel Arnold
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "../common/picogus.h"
+#include "flash_settings.h"
+
+extern int32_t opl_volume;
+extern int32_t sb_volume;
+extern int32_t cd_audio_volume;
+extern int32_t gus_volume;
+extern int32_t psg_volume;
+
+
+extern int32_t set_volume_scale (uint8_t percent);
+extern int32_t scale_sample (int32_t sample, int32_t scale, int clamp);
+
+void set_volume(uint16_t mode);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Adds options in pgusinit for
/mainvol
/oplvol
/sbvol
/gusvol
/psgvol 

Notes: OPL has been gained by 4x on the source which should level it out close to line level when maxed out or there is instrument accumulation. I think the original implementation had attenuated the output for plenty of head room. Clipping is still possible on the output, but can be attenuated properly with /oplvol x. 

Sound Blaster input volume has also been reduced to 50% to balance it out with line level output. I think this is correct since it was heavily distorting the output on some games. This seems to be balanced closer to GUS and OPL now. 

One additional change that snuck in is here [Check for rate change]https://github.com/polpo/picogus/commit/c84773c562cf7ca839d25b10255bd43efd161623#diff-78448aaa3673f77460fe1158d0b871f8148eee789a4262458899d46c51b877deR271(url). This just checks to see if the rate has changed before adjusting so that it is not happening on every loop through. Should be fine and add a small amount of optimization, but worth noting so you are aware of the change. 

