### PR TITLE
Revert "protocol == 1 it's never reached because b is never == 512"

### DIFF
--- a/pgusinit/pgusinit.c
+++ b/pgusinit/pgusinit.c
@@ -628,7 +628,7 @@ static int write_firmware(const char* fw_filename)
             return 14;
         }
 
-        for (uint16_t b = 0; b < 511; ++b) {
+        for (uint16_t b = 0; b < 512; ++b) {
             // Write firmware byte
             outp(DATA_PORT_HIGH, uf2_buf.buf[b]);
             if (b == 512 && protocol == 1) {


### PR DESCRIPTION
Reverts polpo/picogus#135

Whoops, this is actually at odds with the other fix for this bug. Reverting